### PR TITLE
Fix attempts to send an empty acknowledge request

### DIFF
--- a/lib/broadway_cloud_pub_sub/google_api_client.ex
+++ b/lib/broadway_cloud_pub_sub/google_api_client.ex
@@ -66,6 +66,8 @@ defmodule BroadwayCloudPubSub.GoogleApiClient do
     |> acknowledge_messages(ack_ref)
   end
 
+  defp acknowledge_messages([], _), do: :ok
+
   defp acknowledge_messages(messages, {_pid, ref}) do
     ack_ids = Enum.map(messages, &extract_ack_id/1)
 


### PR DESCRIPTION
`GoogleApiClient` will no longer attempt to send an acknowledge request when the list of successful messages is empty.