### PR TITLE
require :broadway ~> 0.3.0

### DIFF
--- a/lib/broadway_cloud_pub_sub/google_api_client.ex
+++ b/lib/broadway_cloud_pub_sub/google_api_client.ex
@@ -96,6 +96,7 @@ defmodule BroadwayCloudPubSub.GoogleApiClient do
       {data, metadata} =
         message
         |> decode_message()
+        |> Map.from_struct()
         |> Map.pop(:data)
 
       %Message{

--- a/lib/broadway_cloud_pub_sub/google_api_client.ex
+++ b/lib/broadway_cloud_pub_sub/google_api_client.ex
@@ -92,10 +92,16 @@ defmodule BroadwayCloudPubSub.GoogleApiClient do
 
   defp wrap_received_messages({:ok, %{receivedMessages: received_messages}}, ack_ref)
        when is_list(received_messages) do
-    Enum.map(received_messages, fn received_message ->
+    Enum.map(received_messages, fn %{message: message, ackId: ack_id} ->
+      {data, metadata} =
+        message
+        |> decode_message()
+        |> Map.pop(:data)
+
       %Message{
-        data: decode_message(received_message.message),
-        acknowledger: {__MODULE__, ack_ref, received_message.ackId}
+        data: data,
+        metadata: metadata,
+        acknowledger: {__MODULE__, ack_ref, ack_id}
       }
     end)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule BroadwayCloudPubSub.MixProject do
 
   defp deps do
     [
-      {:broadway, "~> 0.2.0"},
+      {:broadway, "~> 0.3.0"},
       {:google_api_pub_sub, "~> 0.4"},
       {:goth, "~> 0.6", optional: true},
       {:uuid, "~> 1.0", only: :test},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "broadway": {:hex, :broadway, "0.2.0", "b92703f9b0bca9bc8aa201ea6ab70be9ca53ed74b47674b340f445a218a3427b", [:mix], [{:gen_stage, "~> 0.14", [hex: :gen_stage, repo: "hexpm", optional: false]}], "hexpm"},
+  "broadway": {:hex, :broadway, "0.3.0", "0963c0507f0abee2a98b97021cb76a9db5f426cb27a31fcdbcbd7fd5977def5c", [:mix], [{:gen_stage, "~> 0.14", [hex: :gen_stage, repo: "hexpm", optional: false]}], "hexpm"},
   "certifi": {:hex, :certifi, "2.5.1", "867ce347f7c7d78563450a18a6a28a8090331e77fa02380b4a21962a65d36ee5", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.20.1", "88eaa16e67c505664fd6a66f42ddb962d424ad68df586b214b71443c69887123", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
**Breaking Change!!**

Updates to Broadway v0.3.0 to take advantage of the metadata property on `Broadway.Message`.

Instead of getting a `Broadway.Message` that looks like this:
```elixir
%Broadway.Message{data: %GoogleApi.PubSub.V1.Model.PubsubMessage{attributes: nil, data: "Hello!", messageId: "1", publishTime: #DateTime<2019-05-08 19:34:32Z>}}
```

you'll get one that looks like this:
```elixir
%Broadway.Message{data: "Hello!", metadata: %{attributes: nil, messageId: "2", publishTime: #DateTime<2019-05-08 19:53:35Z>}}
```

